### PR TITLE
compiler

### DIFF
--- a/src/main/antlr/rml/parser/RML.g4
+++ b/src/main/antlr/rml/parser/RML.g4
@@ -93,7 +93,9 @@ dataExp: BOOLEAN # boolDataExp
 
 // identifier classes (don't make them lexical, they will get priority over each other)
 evtypeId: LOWERCASE_ID ;
-fieldKey: LOWERCASE_ID ;
+fieldKey: LOWERCASE_ID # idFieldKey
+	  | STRING # stringFieldKey
+	  ;	  
 evtypeVar: LOWERCASE_ID ;
 expVar: LOWERCASE_ID ;
 expId: UPPERCASE_ID ;

--- a/src/main/kotlin/compiler/prolog/PrologCompiler.kt
+++ b/src/main/kotlin/compiler/prolog/PrologCompiler.kt
@@ -38,9 +38,12 @@ class PrologCompiler(private val writer: BufferedWriter) {
         if (term.args.isEmpty() && term.functor.matches(Regex("[a-z]\\w*"))) {
             writer.write(term.functor)
         }
-        // if it's an atom just print it quoted
+        // just an atom
         else if (term.arity == 0) {
-            writer.write("'${term.functor}'")
+            if (term.functor.startsWith('\'') && term.functor.endsWith('\''))
+                writer.write(term.functor)
+            else
+                writer.write("'${term.functor}'")
         }
         // if functor is binary and not a word, print as infix
         else if (term.args.size == 2 && !term.functor.first().isLetter()) {

--- a/src/main/kotlin/compiler/rml/parser/AstBuilder.kt
+++ b/src/main/kotlin/compiler/rml/parser/AstBuilder.kt
@@ -271,6 +271,14 @@ fun buildEventType(ctx: EvtypeContext) = EventType(
 )
 
 fun buildField(ctx: FieldContext) = ObjectEventExpression.Field(
-        ctx.fieldKey().LOWERCASE_ID().text,
+        ctx.fieldKey().accept(FieldKeyBuilder),//ctx.fieldKey().FIELD_KEY().text,
         ctx.eventExp().accept(EventExpressionBuilder)
 )
+
+object FieldKeyBuilder : NoDefaultVisitor<String>() {
+    override fun visitIdFieldKey(ctx: IdFieldKeyContext) =
+            ctx.LOWERCASE_ID().text
+
+    override fun visitStringFieldKey(ctx: StringFieldKeyContext) =
+            ctx.STRING().text
+}


### PR DESCRIPTION
added support for generic field keywords with arbitrary strings
modified:   src/main/antlr/rml/parser/RML.g4
modified:   src/main/kotlin/compiler/prolog/PrologCompiler.kt
modified:   src/main/kotlin/compiler/rml/parser/AstBuilder.kt