### PR TITLE
compiler

### DIFF
--- a/src/main/antlr/rml/parser/RML.g4
+++ b/src/main/antlr/rml/parser/RML.g4
@@ -48,6 +48,7 @@ exp: exp '*' # starExp
    | exp '+' # plusExp
    | exp '?' # optionalExp
    | exp '!' # closureExp
+   | exp '{' dataExp '}' # timesExp
    | <assoc=right> exp exp # catExp
    | exp '/\\' exp # andExp
    | exp '\\/' exp # orExp

--- a/src/main/kotlin/compiler/calculus/Ast.kt
+++ b/src/main/kotlin/compiler/calculus/Ast.kt
@@ -53,6 +53,7 @@ data class PlusExpression<ET, DE>(val expression: Expression<ET, DE>): Expressio
 
 data class PrefixClosureExpression<ET, DE>(val expression: Expression<ET, DE>): Expression<ET, DE>()
 
+data class TimesExpression<ET, DE>(val expression: Expression<ET, DE>, val num: DE): Expression<ET, DE>()
 data class FilterExpression<ET, DE>(val eventType: ET,
                                     val filteredExpression: Expression<ET, DE>,
                                     val unfilteredExpression: Expression<ET, DE>): Expression<ET, DE>()

--- a/src/main/kotlin/compiler/calculus/Compiler.kt
+++ b/src/main/kotlin/compiler/calculus/Compiler.kt
@@ -56,6 +56,7 @@ class Compiler<ET, DE>(val eventTypeCompiler: (ET) -> Term, val dataExpressionCo
         is StarExpression -> CompoundTerm("star", compile(expression.expression))
         is OptionalExpression -> CompoundTerm("optional", compile(expression.expression))
         is PlusExpression -> CompoundTerm("plus", compile(expression.expression))
+        is TimesExpression -> CompoundTerm("times",compile(expression.expression),dataExpressionCompiler(expression.num))
         is PrefixClosureExpression -> CompoundTerm("clos", compile(expression.expression))
         // because of Prolog operator precedence, ET>>T1;T2 is (ET>>T1);T2
         is FilterExpression -> CompoundTerm(";",

--- a/src/main/kotlin/compiler/rml/ast/CalculusCompiler.kt
+++ b/src/main/kotlin/compiler/rml/ast/CalculusCompiler.kt
@@ -30,6 +30,7 @@ object CalculusCompiler {
         is StarExpression -> true
         is PlusExpression -> hasEmptyTrace(expression.exp)
         is OptionalExpression -> true
+        is TimesExpression -> hasEmptyTrace(expression.exp) || expression.num is IntDataExpression && expression.num.equals(IntDataExpression(0))
         is PrefixClosureExpression -> true
         // more compact form is ConcatExpression, is AndExpression, is ShuffleExpression -> ... does not work
         // Unresolved reference: left/right
@@ -60,6 +61,7 @@ object CalculusCompiler {
         is StarExpression -> isContractive(expression.exp,depth)
         is PlusExpression -> isContractive(expression.exp,depth)
         is OptionalExpression -> isContractive(expression.exp,depth)
+        is TimesExpression -> isContractive(expression.exp,depth)
         is PrefixClosureExpression -> isContractive(expression.exp,depth)
         // more compact form is ConcatExpression, is AndExpression, is ShuffleExpression -> ... does not work
         // Unresolved reference: left/right
@@ -125,6 +127,7 @@ object CalculusCompiler {
         is PlusExpression -> PlusExpression(compile(expression.exp))
         is OptionalExpression -> OptionalExpression(compile(expression.exp))
         is PrefixClosureExpression -> PrefixClosureExpression(compile(expression.exp))
+        is TimesExpression -> if(expression.num is IntDataExpression) TimesExpression(compile(expression.exp),expression.num) else throw RuntimeException("Expected an int literal argument for the times regex operator")
         is ConcatExpression -> ConcatenationExpression(compile(expression.left), compile(expression.right))
         is AndExpression -> AndExpression(compile(expression.left), compile(expression.right))
         is OrExpression -> OrExpression(compile(expression.left), compile(expression.right))

--- a/src/main/kotlin/compiler/rml/ast/Expression.kt
+++ b/src/main/kotlin/compiler/rml/ast/Expression.kt
@@ -8,6 +8,7 @@ data class PlusExpression(val exp: Expression): Expression()
 data class OptionalExpression(val exp: Expression): Expression()
 
 data class PrefixClosureExpression(val exp: Expression): Expression()
+data class TimesExpression(val exp: Expression, val num: DataExpression): Expression()
 
 // binary operators
 data class ConcatExpression(val left: Expression, val right: Expression): Expression()

--- a/src/main/kotlin/compiler/rml/parser/AstBuilder.kt
+++ b/src/main/kotlin/compiler/rml/parser/AstBuilder.kt
@@ -134,6 +134,10 @@ object ExpressionBuilder: NoDefaultVisitor<Expression>() {
     override fun visitClosureExp(ctx: ClosureExpContext) =
             PrefixClosureExpression(ctx.exp().accept(this))
 
+    override fun visitTimesExp(ctx: TimesExpContext) = TimesExpression(
+        ctx.exp().accept(this),
+        ctx.dataExp().accept(DataExpressionBuilder)
+    )
     override fun visitCatExp(ctx: CatExpContext) = ConcatExpression(
             ctx.exp(0).accept(this),
             ctx.exp(1).accept(this)


### PR DESCRIPTION
added support for the reg-ex operator exp{n} (exp repeated exactly n times, with n int literal)
modified:   src/main/antlr/rml/parser/RML.g4
modified:   src/main/kotlin/compiler/calculus/Ast.kt
modified:   src/main/kotlin/compiler/calculus/Compiler.kt
modified:   src/main/kotlin/compiler/rml/ast/CalculusCompiler.kt
modified:   src/main/kotlin/compiler/rml/ast/Expression.kt
modified:   src/main/kotlin/compiler/rml/parser/AstBuilder.kt